### PR TITLE
Added support for Ignoring certain groups from the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ E.g.
     'trix_allowed_tags' => '<code><p><b><u><a><br><ul><li><ol><pre><h2><h3><h4><h5><del><blockquote><dl><dd><strong>',
 ```
 
+### Ignoring Groups
+You may also ignore certain groups of translations to be shown on nova interface. Create an array with keys you want to ignore.
+
+E.g.
+```php
+    /*
+    |--------------------------------------------------------------------------
+    | Ignore Groups
+    |--------------------------------------------------------------------------
+    | This will ignore certain groups from the translations UI
+    | Supports an array of keys
+    |
+    */
+
+    'ignore_groups' => ['auth','pagination','passwords','routes','nova','nova/validation'],
+```
+
 ## Credits
 
 We used [Joe Dixon's](https://github.com/joedixon) translation libraries as a source of technical expertise and inspiration:

--- a/src/Http/Controllers/TranslationController.php
+++ b/src/Http/Controllers/TranslationController.php
@@ -46,6 +46,12 @@ class TranslationController extends AbstractTranslationController
             \Arr::forget($groups,TranslationManager::getConfig('ignore_groups',[]));
         }
 
+        dd(
+            $groups,
+            TranslationManager::getConfig('ignore_groups',[])
+
+        );
+
         $languages = $this->getLocalesData();
         $translations = $this->getTranslations($languages, $groups);
 

--- a/src/Http/Controllers/TranslationController.php
+++ b/src/Http/Controllers/TranslationController.php
@@ -41,16 +41,7 @@ class TranslationController extends AbstractTranslationController
     public function index(): JsonResponse
     {
         $groups = $this->chainedTranslationManager->getTranslationGroups();
-
-        if(!empty(TranslationManager::getConfig('ignore_groups',[]))){
-            \Arr::forget($groups,TranslationManager::getConfig('ignore_groups',[]));
-        }
-
-        dd(
-            $groups,
-            TranslationManager::getConfig('ignore_groups',[])
-
-        );
+        \Arr::forget($groups,TranslationManager::getConfig('ignore_groups',[]));
 
         $languages = $this->getLocalesData();
         $translations = $this->getTranslations($languages, $groups);

--- a/src/Http/Controllers/TranslationController.php
+++ b/src/Http/Controllers/TranslationController.php
@@ -43,7 +43,7 @@ class TranslationController extends AbstractTranslationController
         $groups = $this->chainedTranslationManager->getTranslationGroups();
         //$groups = collect($groups)->diff(TranslationManager::getConfig('ignore_groups',[]))->toArray();
 
-        dd($groups,collect($groups)->diff(TranslationManager::getConfig('ignore_groups',[]))->toArray());
+        dd($groups,collect($groups)->diff(TranslationManager::getConfig('ignore_groups',[]))->values()->toArray());
         $languages = $this->getLocalesData();
         $translations = $this->getTranslations($languages, $groups);
 

--- a/src/Http/Controllers/TranslationController.php
+++ b/src/Http/Controllers/TranslationController.php
@@ -41,14 +41,15 @@ class TranslationController extends AbstractTranslationController
     public function index(): JsonResponse
     {
         $groups = $this->chainedTranslationManager->getTranslationGroups();
-        $groups = collect($groups)->diff(TranslationManager::getConfig('ignore_groups',[]));
+        //$groups = collect($groups)->diff(TranslationManager::getConfig('ignore_groups',[]))->toArray();
 
+        dd($groups,collect($groups)->diff(TranslationManager::getConfig('ignore_groups',[]))->toArray());
         $languages = $this->getLocalesData();
-        $translations = $this->getTranslations($languages, $groups->toArray());
+        $translations = $this->getTranslations($languages, $groups);
 
         return response()->json([
             'source_language' => config('app.locale'),
-            'groups' => $groups->toArray(),
+            'groups' => $groups,
             'languages' => $languages,
             'config' => TranslationManager::getConfig(),
             'translations' => [

--- a/src/Http/Controllers/TranslationController.php
+++ b/src/Http/Controllers/TranslationController.php
@@ -43,6 +43,11 @@ class TranslationController extends AbstractTranslationController
         $groups = $this->chainedTranslationManager->getTranslationGroups();
         \Arr::forget($groups,TranslationManager::getConfig('ignore_groups',[]));
 
+        dd(
+            $groups,
+            TranslationManager::getConfig('ignore_groups',[])
+        );
+
         $languages = $this->getLocalesData();
         $translations = $this->getTranslations($languages, $groups);
 

--- a/src/Http/Controllers/TranslationController.php
+++ b/src/Http/Controllers/TranslationController.php
@@ -41,8 +41,12 @@ class TranslationController extends AbstractTranslationController
     public function index(): JsonResponse
     {
         $groups = $this->chainedTranslationManager->getTranslationGroups();
-        $languages = $this->getLocalesData();
 
+        if(!empty(TranslationManager::getConfig('ignore_groups',[]))){
+            \Arr::forget($groups,TranslationManager::getConfig('ignore_groups',[]));
+        }
+
+        $languages = $this->getLocalesData();
         $translations = $this->getTranslations($languages, $groups);
 
         return response()->json([

--- a/src/Http/Controllers/TranslationController.php
+++ b/src/Http/Controllers/TranslationController.php
@@ -41,9 +41,8 @@ class TranslationController extends AbstractTranslationController
     public function index(): JsonResponse
     {
         $groups = $this->chainedTranslationManager->getTranslationGroups();
-        //$groups = collect($groups)->diff(TranslationManager::getConfig('ignore_groups',[]))->toArray();
+        $groups = collect($groups)->diff(TranslationManager::getConfig('ignore_groups',[]))->values()->toArray();
 
-        dd($groups,collect($groups)->diff(TranslationManager::getConfig('ignore_groups',[]))->values()->toArray());
         $languages = $this->getLocalesData();
         $translations = $this->getTranslations($languages, $groups);
 

--- a/src/Http/Controllers/TranslationController.php
+++ b/src/Http/Controllers/TranslationController.php
@@ -41,19 +41,19 @@ class TranslationController extends AbstractTranslationController
     public function index(): JsonResponse
     {
         $groups = $this->chainedTranslationManager->getTranslationGroups();
-        \Arr::forget($groups,TranslationManager::getConfig('ignore_groups',[]));
+        $groups = collect($groups);
+        $ignore = collect(TranslationManager::getConfig('ignore_groups',[]));
 
         dd(
-            $groups,
-            TranslationManager::getConfig('ignore_groups',[])
+            $groups->diff($ignore)
         );
 
         $languages = $this->getLocalesData();
-        $translations = $this->getTranslations($languages, $groups);
+        $translations = $this->getTranslations($languages, $groups->toArray());
 
         return response()->json([
             'source_language' => config('app.locale'),
-            'groups' => $groups,
+            'groups' => $groups->toArray(),
             'languages' => $languages,
             'config' => TranslationManager::getConfig(),
             'translations' => [

--- a/src/Http/Controllers/TranslationController.php
+++ b/src/Http/Controllers/TranslationController.php
@@ -41,12 +41,7 @@ class TranslationController extends AbstractTranslationController
     public function index(): JsonResponse
     {
         $groups = $this->chainedTranslationManager->getTranslationGroups();
-        $groups = collect($groups);
-        $ignore = collect(TranslationManager::getConfig('ignore_groups',[]));
-
-        dd(
-            $groups->diff($ignore)
-        );
+        $groups = collect($groups)->diff(TranslationManager::getConfig('ignore_groups',[]));
 
         $languages = $this->getLocalesData();
         $translations = $this->getTranslations($languages, $groups->toArray());


### PR DESCRIPTION
This pull request brings a feature to ignore certain translation keys from the Nova user interface, making it clear and also at same time, making sure the end-user does not translation unecessary keys.